### PR TITLE
Field `_entityIdentity` isn't needed?

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/TrackableExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/TrackableExtensionsTests.cs
@@ -534,15 +534,16 @@ namespace TrackableEntities.Client.Tests.Extensions
             customer1.SetEntityIdentifier();
             Guid entityIdentifier = GetEntityIdentifier(customer1);
             customer2.SetEntityIdentifier(entityIdentifier);
-
-            customer1.SetEntityIdentifier(default(Guid)); // Cleared
-            customer1.SetEntityIdentifier(); // Reset
+            bool wereEquatable = customer1.IsEquatable(customer2);
 
             // Act
+            customer1.SetEntityIdentifier(default(Guid)); // Cleared
+            customer1.SetEntityIdentifier(); // Reset
             bool areEquatable = customer1.IsEquatable(customer2);
 
             // Assert
-            Assert.IsTrue(areEquatable);
+            Assert.IsTrue(wereEquatable);
+            Assert.IsFalse(areEquatable);
         }
 
         #endregion

--- a/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
@@ -74,8 +74,7 @@ namespace TrackableEntities.Client
                     if (updatedItem.GetEntityIdentifier() == default(Guid))
                     {
                         Guid origEntityIdentifier = origItem.GetEntityIdentifier();
-                        updatedItem.SetEntityIdentity(origEntityIdentifier);
-                        updatedItem.SetEntityIdentifier(); 
+                        updatedItem.SetEntityIdentifier(origEntityIdentifier); 
                     }
                 }
                 

--- a/Source/TrackableEntities.Client/Constants.cs
+++ b/Source/TrackableEntities.Client/Constants.cs
@@ -31,9 +31,6 @@ namespace TrackableEntities.Client
 
             /// <summary>Entity identifier property</summary>
             public const string EntityIdentifierProperty = "EntityIdentifier";
-
-            /// <summary>Entity identify field</summary>
-            public const string EntityIdentifyField = "_entityIdentity";
         }
 
         /// <summary>

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -462,8 +462,6 @@ namespace TrackableEntities.Client
             // Set entity identifier prop value explicitly
             if (value != null)
             {
-                if ((Guid)value != default(Guid))
-                    item.SetEntityIdentity((Guid)value);
                 property.SetValue(item, value, null);
                 return;
             }
@@ -478,30 +476,6 @@ namespace TrackableEntities.Client
                 var entityIdentity = item.GetOrSetEntityIdentity();
                 property.SetValue(item, entityIdentity, null);
             }
-        }
-
-        /// <summary>
-        /// Get value of entity identity used for setting EntityIdentifier.
-        /// </summary>
-        /// <param name="item">ITrackable object</param>
-        /// <returns>Value of entity identity field</returns>
-        public static Guid GetEntityIdentity(this ITrackable item)
-        {
-            var field = GetEntityIdentifyField(item.GetType());
-            if (field == null) return default(Guid);
-            return (Guid)field.GetValue(item);
-        }
-
-        /// <summary>
-        /// Set value of entity identity used for setting EntityIdentifier.
-        /// </summary>
-        /// <param name="item">ITrackable object</param>
-        /// <param name="value">Value for entity identity field</param>
-        public static void SetEntityIdentity(this ITrackable item, Guid value)
-        {
-            var field = GetEntityIdentifyField(item.GetType());
-            if (field == null) return;
-            field.SetValue(item, value);
         }
 
         /// <summary>
@@ -551,23 +525,16 @@ namespace TrackableEntities.Client
             return property;
         }
 
-        private static FieldInfo GetEntityIdentifyField(Type type)
-        {
-            var property = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
-                .SingleOrDefault(m => m.Name == Constants.EquatableMembers.EntityIdentifyField);
-            return property;
-        }
-
         private static Guid GetOrSetEntityIdentity(this ITrackable item)
         {
             var newIdentity = Guid.NewGuid();
-            var field = GetEntityIdentifyField(item.GetType());
-            if (field != null)
+            var property = GetEntityIdentifierProperty(item.GetType());
+            if (property != null)
             {
-                var entityIdentity = (Guid)field.GetValue(item);
+                var entityIdentity = (Guid)property.GetValue(item, null);
                 if (entityIdentity != default(Guid))
                     return entityIdentity;
-                field.SetValue(item, newIdentity);
+                property.SetValue(item, newIdentity, null);
             }
             return newIdentity;
         }


### PR DESCRIPTION
Hi Tony,

Back to our old discussion https://trackable.codeplex.com/discussions/554515. I just removed any handling of `_entityIdentity` field and it still passes all tests. My application also works fine. Maybe some of your TE-based apps will fail. If so then it would at least be worth adding another unit test to depict the real need for `_entityIdentity`, but so far my feeling is telling me it is exactly one field too much for the task.

Please review and if this attempt incurs no other problems, then the T4 templates and sample apps must also be cleaned up (here I would count on your help).

Thanks,
AZ
