### PR TITLE
Check if property is writeable, when using readonly (calculated) properties on your entities

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/Customer.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/Customer.cs
@@ -8,6 +8,20 @@ namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
     public class Customer : ModelBase<Customer>, ITrackable, IEquatable<Customer>,
         IRefPropertyChangeTrackerResolver
     {
+        /// <summary>
+        /// Testing read-only calculated property
+        /// </summary>
+        public string CustomerIdAndName
+        {
+            get
+            {
+                return string.Format(
+                    "{0} - {1}",
+                    CustomerId.ToString(),
+                    CustomerName == null ? string.Empty : CustomerName.ToString());
+            }
+        }
+
         private string _customerId;
         public string CustomerId
         {
@@ -26,7 +40,7 @@ namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
             get { return _customerName; }
             set
             {
-                if (value == _customerName) return;
+                if (value == _customerName) return; 
                 _customerName = value;
                 NotifyPropertyChanged(m => m.CustomerName);
             }
@@ -113,5 +127,59 @@ namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
                 return TerritoryChangeTracker;
             return null;
         }
+
+        #region Testing Non-Trackable properties for performance reflection
+
+        public int NoneTrackableProperty01 { get; set; }
+        public int NoneTrackableProperty02 { get; set; }
+        public int NoneTrackableProperty03 { get; set; }
+        public int NoneTrackableProperty04 { get; set; }
+        public int NoneTrackableProperty05 { get; set; }
+        public int NoneTrackableProperty06 { get; set; }
+        public int NoneTrackableProperty07 { get; set; }
+        public int NoneTrackableProperty08 { get; set; }
+        public int NoneTrackableProperty09 { get; set; }
+
+        public int NoneTrackableProperty11 { get; set; }
+        public int NoneTrackableProperty12 { get; set; }
+        public int NoneTrackableProperty13 { get; set; }
+        public int NoneTrackableProperty14 { get; set; }
+        public int NoneTrackableProperty15 { get; set; }
+        public int NoneTrackableProperty16 { get; set; }
+        public int NoneTrackableProperty17 { get; set; }
+        public int NoneTrackableProperty18 { get; set; }
+        public int NoneTrackableProperty19 { get; set; }
+
+        public int NoneTrackableProperty21 { get; set; }
+        public int NoneTrackableProperty22 { get; set; }
+        public int NoneTrackableProperty23 { get; set; }
+        public int NoneTrackableProperty24 { get; set; }
+        public int NoneTrackableProperty25 { get; set; }
+        public int NoneTrackableProperty26 { get; set; }
+        public int NoneTrackableProperty27 { get; set; }
+        public int NoneTrackableProperty28 { get; set; }
+        public int NoneTrackableProperty29 { get; set; }
+
+        public int NoneTrackableProperty31 { get; set; }
+        public int NoneTrackableProperty32 { get; set; }
+        public int NoneTrackableProperty33 { get; set; }
+        public int NoneTrackableProperty34 { get; set; }
+        public int NoneTrackableProperty35 { get; set; }
+        public int NoneTrackableProperty36 { get; set; }
+        public int NoneTrackableProperty37 { get; set; }
+        public int NoneTrackableProperty38 { get; set; }
+        public int NoneTrackableProperty39 { get; set; }
+
+        public int NoneTrackableProperty41 { get; set; }
+        public int NoneTrackableProperty42 { get; set; }
+        public int NoneTrackableProperty43 { get; set; }
+        public int NoneTrackableProperty44 { get; set; }
+        public int NoneTrackableProperty45 { get; set; }
+        public int NoneTrackableProperty46 { get; set; }
+        public int NoneTrackableProperty47 { get; set; }
+        public int NoneTrackableProperty48 { get; set; }
+        public int NoneTrackableProperty49 { get; set; }
+
+        #endregion 
     }
 }

--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
@@ -163,6 +163,31 @@ namespace TrackableEntities.Client.Tests.Extensions
             Assert.Contains("CustomerName", (ICollection)origOrder.Customer.ModifiedProperties);
         }
 
+        [Test]
+        public void MergeChanges_Should_Handle_Readonly_Properties()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var origCustomer = database.Customers[0];
+            var changeTracker = new ChangeTrackingCollection<Customer>(origCustomer);
+            var oldCustomerId = origCustomer.CustomerId;
+            origCustomer.CustomerId = "TEST";
+            var updatedCustomer = UpdateCustomers(database, origCustomer)[0];
+
+            // Act: reset the origCustomer so read-only value becomes different
+            changeTracker.Tracking = false;
+            origCustomer.CustomerId = oldCustomerId;
+            changeTracker.Tracking = true;
+            changeTracker.MergeChanges(updatedCustomer);
+
+            // Assert
+            Assert.AreEqual(updatedCustomer.CustomerId, origCustomer.CustomerId);
+            //Assert.AreEqual(updatedCustomer.Customer.CustomerId, origCustomer.Customer.CustomerId);
+            //Assert.AreEqual(updatedCustomer.CustomerDate, origCustomer.CustomerDate);
+        }
+
+        #endregion
+
         #endregion
 
         #region MergeChanges: Multiple Entities
@@ -476,8 +501,6 @@ namespace TrackableEntities.Client.Tests.Extensions
             // Act
             changeTracker.MergeChanges();
         }
-
-        #endregion
 
         #endregion
 
@@ -1194,6 +1217,28 @@ namespace TrackableEntities.Client.Tests.Extensions
                 updatedOrders.Add(updatedOrder);
             }
             return updatedOrders;
+        }
+
+
+        private List<Customer> UpdateCustomers(MockNorthwind database, params Customer[] origCustomers)
+        {
+            var updatedCustomers = new List<Customer>();
+            for (int i = 0; i < origCustomers.Length; i++)
+            {
+                // Simulate serialization
+                var origCustomer = origCustomers[i];
+                var updatedCustomer = origCustomer.Clone<Customer>();
+
+                // Simulate load related entities
+                //string customerId = i == 0 ? "ALFKI" : "ANATR";
+                //updatedCustomer.Customer = database.Customers.Single(c => c.CustomerId == customerId);
+
+                // Simulate db-generated values
+                //updatedCustomer.cust = origCustomer.CustomerDate.AddDays(1);
+                updatedCustomer.AcceptChanges();
+                updatedCustomers.Add(updatedCustomer);
+            }
+            return updatedCustomers;
         }
 
         private List<Order> UpdateOrdersWithDetails(MockNorthwind database, IEnumerable<Order> changes)

--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/TrackableExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/TrackableExtensionsTests.cs
@@ -253,27 +253,18 @@ namespace TrackableEntities.Client.Tests.Extensions
         public void Collection_GetChanges_Should_Add_Only_Added_Modified_Deleted_Children()
         {
             // Arrange
-            var parent = new Parent("Parent")
-            {
-                Children = new ChangeTrackingCollection<Child>
-                    {
-                        new Child("Child1"), 
-                        new Child("Child2"),
-                        new Child("Child3")
-                    }
-            };
-            var changeTracker = new ChangeTrackingCollection<Parent>(parent);
-            parent.Children.Add(new Child("Child4"));
-            parent.Children[0].Name += "_Changed";
-            parent.Children.RemoveAt(2);
+            var changeTracker = new ChangeTrackingCollection<Customer>(true);
+            for (int i = 0; i < 500; i++)
+			{
+                changeTracker.Add(new Customer() { CustomerId = i.ToString(), CustomerName = "TEST_" + i.ToString() });
+			 
+			}
 
             // Act
             var changes = changeTracker.GetChanges();
-            var changedParent = changes.First();
 
             // Assert
-            Assert.AreEqual(1, changes.Count);
-            Assert.AreEqual(3, changedParent.Children.Count);
+            Assert.AreEqual(500, changes.Count);
         }
 
         #endregion

--- a/Source/Tests/TrackableEntities.EF.5.Tests/App.config
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/App.config
@@ -7,7 +7,7 @@
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="Data Source=(local)\sqlexpress; Integrated Security=True; MultipleActiveResultSets=True" />
+        <parameter value="Data Source=localhost; Integrated Security=True; MultipleActiveResultSets=True" />
       </parameters>
     </defaultConnectionFactory>
   </entityFramework>

--- a/Source/Tests/TrackableEntities.EF.6.Tests/App.config
+++ b/Source/Tests/TrackableEntities.EF.6.Tests/App.config
@@ -4,7 +4,11 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="Data Source=localhost; Integrated Security=True; MultipleActiveResultSets=True" />
+      </parameters>
+    </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>

--- a/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
@@ -251,8 +251,11 @@ namespace TrackableEntities.Client
                 bool isTracking = changeTracker.Tracking;
                 changeTracker.Tracking = false;
 
-                // Set target item prop value
-                prop.SetValue(targetItem, sourceValue, null);
+                // Set target item prop value, if writeable
+                if (prop.CanWrite)
+                {
+                    prop.SetValue(targetItem, sourceValue, null);
+                }                
 
                 // Reset change-tracking
                 changeTracker.Tracking = isTracking;

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -295,8 +295,13 @@ namespace TrackableEntities.Client
                 bool hasDownstreamChanges = false;
 
                 // Iterate entity properties
-                foreach (var prop in item.GetType().GetProperties())
+                var propTrackingList = GetITrackableProperties(item.GetType());
+                foreach (var propTracking in propTrackingList)
+                //foreach (var prop in item.GetType().GetProperties())
                 {
+                    // Get the property info
+                    var prop = propTracking.PropertyInfo;
+
                     // Process 1-1 and M-1 properties
                     var trackableRef = prop.GetValue(item, null) as ITrackable;
 
@@ -360,6 +365,54 @@ namespace TrackableEntities.Client
                 if (hasDownstreamChanges || item.TrackingState != TrackingState.Unchanged)
                     yield return item;
             }
+        }
+
+        /// <summary>
+        /// Get the ITrackable properties from an entity.
+        /// Use caching to 
+        /// </summary>
+        /// <param name="entityType"></param>
+        /// <returns></returns>
+        internal static IEnumerable<ExtendedPropertyInfo> GetITrackableProperties(Type entityType)
+        {
+            // Resolve from cache
+            List<ExtendedPropertyInfo> aITrackablePropertyList = null;
+            //if (Cache.Items.TryGetValue(entityType, out aITrackablePropertyList))
+            //{
+            //    return aITrackablePropertyList;
+            //}
+
+            // Iterate entity properties
+            aITrackablePropertyList = new List<ExtendedPropertyInfo>();
+            foreach (var prop in entityType.GetProperties())
+            {
+                Type aPropertyType = null;
+                bool IsManyRelation = false;
+                if (typeof(ITrackable).IsAssignableFrom(prop.PropertyType))
+                {
+                    aPropertyType = prop.PropertyType;
+                    IsManyRelation = false;
+                }
+                //else if (typeof(ITrackingCollection).IsAssignableFrom(prop.PropertyType))
+                else if (typeof(IEnumerable<ITrackable>).IsAssignableFrom(prop.PropertyType))
+                {
+                    aPropertyType = prop.PropertyType.GetGenericArguments().First();
+                    IsManyRelation = true;
+                }
+
+                if (aPropertyType != null)
+                {
+                    var aExtendedPropertyInfo = new ExtendedPropertyInfo(prop, aPropertyType);
+                    aExtendedPropertyInfo.IsManyRelation = IsManyRelation;
+                    aITrackablePropertyList.Add(aExtendedPropertyInfo);
+                    //yield return aExtendedPropertyInfo;
+                }
+            }
+
+            // Add to cache
+            //Cache.Items.Add(entityType, aITrackablePropertyList);
+            
+            return aITrackablePropertyList;
         }
 
         /// <summary>

--- a/Source/TrackableEntities.Common/Cache.cs
+++ b/Source/TrackableEntities.Common/Cache.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using TrackableEntities.Common;
+using System.Collections;
+using System.Linq.Expressions;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Collections;
+
+namespace TrackableEntities
+{
+    public static class Cache
+    {
+        public static Dictionary<Type, List<ExtendedPropertyInfo>> Items = new Dictionary<Type, List<ExtendedPropertyInfo>>();
+    }
+}

--- a/Source/TrackableEntities.Common/ExtendedPropertyInfo.cs
+++ b/Source/TrackableEntities.Common/ExtendedPropertyInfo.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using TrackableEntities.Common;
+using System.Collections;
+using System.Linq.Expressions;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace TrackableEntities
+{
+    public class ExtendedPropertyInfo : IEquatable<ExtendedPropertyInfo>
+    {
+        public ExtendedPropertyInfo(PropertyInfo propertyInfo, Type typeInfo)
+        {
+            this.PropertyInfo = propertyInfo;
+            this.TypeInfo = typeInfo;
+        }
+
+        public PropertyInfo PropertyInfo { get; private set; }
+
+        public Type TypeInfo { get; private set; }
+
+        public bool NoUpdate { get; set; }
+
+        public bool ReferenceOnly { get; set; }
+
+        public bool IsManyRelation { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as ExtendedPropertyInfo);
+        }
+
+        public bool Equals(ExtendedPropertyInfo other)
+        {
+            if (Object.ReferenceEquals(other, null))
+                return false;
+            else
+                return (Object.Equals(this.PropertyInfo, other.PropertyInfo));
+        }
+
+        public override int GetHashCode()
+        {
+            return this.GetType().GetHashCode() ^ this.PropertyInfo.GetHashCode();
+        }
+    }
+}

--- a/Source/TrackableEntities.Common/TrackableEntities.Common.csproj
+++ b/Source/TrackableEntities.Common/TrackableEntities.Common.csproj
@@ -71,11 +71,13 @@
     <Compile Include="..\AssemblyVersion.cs">
       <Link>Properties\AssemblyVersion.cs</Link>
     </Compile>
+    <Compile Include="Cache.cs" />
     <Compile Include="ITrackable.cs" />
     <Compile Include="ObjectVisitationHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TrackableExtensions.cs" />
     <Compile Include="TrackingState.cs" />
+    <Compile Include="ExtendedPropertyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">


### PR DESCRIPTION
Issue: MergeChanges Should Skip Read-Only Properties
https://trackable.codeplex.com/workitem/41
