### PR TITLE
Added configuration parameters for LocalDB in test projects.

### DIFF
--- a/Source/Tests.Acceptance/TrackableEntities.Tests.Acceptance/app.config
+++ b/Source/Tests.Acceptance/TrackableEntities.Tests.Acceptance/app.config
@@ -30,7 +30,16 @@
     <add key="xunit.parallelizeTestCollections" value="false" />
   </appSettings>
   <entityFramework>
+    <!--Use this for SQL Server Express or Full-->
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+
+    <!--Use this for SQL LocalDB-->
+    <!--<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>-->
+
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>

--- a/Source/Tests/TrackableEntities.EF.5.Tests/App.config
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/App.config
@@ -7,7 +7,11 @@
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>
+        <!--Use this for SQL Server Express or Full-->
         <parameter value="Data Source=(local)\sqlexpress; Integrated Security=True; MultipleActiveResultSets=True" />
+
+        <!--Use this for SQL LocalDB-->
+        <!--<parameter value="Data Source=(localdb)\MSSQLLocalDB; Integrated Security=True; MultipleActiveResultSets=True" />-->
       </parameters>
     </defaultConnectionFactory>
   </entityFramework>

--- a/Source/Tests/TrackableEntities.EF.6.Tests/App.config
+++ b/Source/Tests/TrackableEntities.EF.6.Tests/App.config
@@ -4,7 +4,16 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
+    <!--Use this for SQL Server Express or Full-->
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+
+    <!--Use this for SQL LocalDB-->
+    <!--<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>-->
+    
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>


### PR DESCRIPTION
I added *commented* configuration parameters for EntityFramework to be able to use LocalDB. Developer has to uncomment this new section and comment section for SQL Express (or Full) to run tests.