### PR TITLE
Added Many-to-Many test

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -152,6 +152,24 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Added, employee.TrackingState);
             Assert.True(employee.Territories.All(t => t.TrackingState == TrackingState.Added));
         }
+        
+        [Fact]
+        public void Adding_And_Removing_The_Same_Territory_Should_Not_Keep_Added_Territory_In_Territory_Collection()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var employee = database.Employees[0];
+            var changeTracker = new ChangeTrackingCollection<Employee>(employee);
+
+            // Act
+            employee.Territories.Add(database.Territories[4]);
+            employee.Territories.Remove(database.Territories[4]);
+
+            // Assert
+            var changes = changeTracker.GetChanges();
+            Assert.Equal(0, changes.Count);
+            Assert.Equal(3, employee.Territories.Count);
+        }
 
         #endregion
 


### PR DESCRIPTION
I think adding and removing the same territory to an employee should leave everything as unchanged.

The GetChanges method works as expected and returns 0 changes.
But the territory is still part of the employee's territory collection.
I have added a failing test.