### PR TITLE
Adding Removed M-M Item Adds It to _deleted Collection

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -152,6 +152,24 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Added, employee.TrackingState);
             Assert.True(employee.Territories.All(t => t.TrackingState == TrackingState.Added));
         }
+        
+        [Fact]
+        public void Adding_And_Removing_The_Same_Territory_Should_Not_Keep_Added_Territory_In_Territory_Collection()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var employee = database.Employees[0];
+            var changeTracker = new ChangeTrackingCollection<Employee>(employee);
+
+            // Act
+            employee.Territories.Add(database.Territories[4]);
+            employee.Territories.Remove(database.Territories[4]);
+
+            // Assert
+            var changes = changeTracker.GetChanges();
+            Assert.Equal(0, changes.Count);
+            Assert.Equal(3, employee.Territories.Count);
+        }
 
         #endregion
 

--- a/Source/TrackableEntities.Client/ChangeTrackingCollection.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingCollection.cs
@@ -235,6 +235,7 @@ namespace TrackableEntities.Client
                 item.SetTracking(false, visitationHelper.Clone(), true);
 
                 // Mark item and trackable collection properties
+                bool manyToManyAdded = Parent != null && item.TrackingState == TrackingState.Added;
                 item.SetState(TrackingState.Deleted, visitationHelper.Clone());
 
                 // Fire EntityChanged event
@@ -242,6 +243,7 @@ namespace TrackableEntities.Client
 
                 // Cache deleted item if not added or already cached
                 if (item.TrackingState != TrackingState.Added
+                    && !manyToManyAdded
                     && !_deletedEntities.Contains(item))
                     _deletedEntities.Add(item);
             }


### PR DESCRIPTION
This PR includes failing test from PR #136 from @MarcDrexler, which shows that calling `GetChanges` on employee.Territories with a `_deleted` item adds it back to the Territories collection.

The probable cause of this behavior is that removing an Added territory sets its state to Unchanged and adds it to the `_deleted` collection, as described in issue #132.

The problem is in the `RemoveItem` method of `ChangeTrackingCollection`, where items are added to `_deleted` if their state is not set to Added.  Because the removed territory has had its state set to Unchanged, it is added to `_deleted`.  Setting the state to Unchanged is correct for M-M relations, so we need to capture that its original state was Added, and then **not** add it to `_deleted`.

The code in question is [here](https://github.com/TrackableEntities/trackable-entities/blob/develop/Source/TrackableEntities.Client/ChangeTrackingCollection.cs#L243-L246):

```csharp
// Cache deleted item if not added or already cached
if (item.TrackingState != TrackingState.Added
    && !_deletedEntities.Contains(item))
    _deletedEntities.Add(item);
```