### PR TITLE
Fix #139: ChangeTrackingCollection is modified when calling GetChanges

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -641,6 +641,26 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Modified, changes.ElementAt(0).TrackingState);
             Assert.Equal(TrackingState.Deleted, changes.ElementAt(2).TrackingState);
         }
+        
+        [Fact]
+        public void GetChanges_Should_Not_Change_Territory_Collection_Of_Tracked_Employee()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var employee = database.Employees[0];
+            var changeTracker = new ChangeTrackingCollection<Employee>(employee);
+
+            // Delete all territories, so employee.Territories.Count is 0
+            employee.Territories.Remove(employee.Territories[2]);
+            employee.Territories.Remove(employee.Territories[1]);
+            employee.Territories.Remove(employee.Territories[0]);
+
+            // Act
+            var changes = changeTracker.GetChanges();
+
+            // Assert
+            Assert.Equal(0, employee.Territories.Count);
+        }
 
         #endregion
 

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -154,36 +154,35 @@ namespace TrackableEntities.Client
                 if (item == null) continue;
 
                 // Prevent endless recursion
-                if (!visitationHelper.TryVisit(item)) continue;
-
-                // Iterate entity properties
-                foreach (var navProp in item.GetNavigationProperties())
+                if (visitationHelper.TryVisit(item))
                 {
-                    // Process 1-1 and M-1 properties
-                    foreach (var refProp in navProp.AsReferenceProperty())
+                    // Iterate entity properties
+                    foreach (var navProp in item.GetNavigationProperties())
                     {
-                        // Get changed ref prop
-                        ITrackingCollection refChangeTracker = item.GetRefPropertyChangeTracker(refProp.Property.Name);
+                        // Process 1-1 and M-1 properties
+                        foreach (var refProp in navProp.AsReferenceProperty())
+                        {
+                            // Get changed ref prop
+                            ITrackingCollection refChangeTracker = item.GetRefPropertyChangeTracker(refProp.Property.Name);
 
-                        // Remove deletes on rep prop
-                        if (refChangeTracker != null) refChangeTracker.RemoveRestoredDeletes(visitationHelper);
-                    }
+                            // Remove deletes on rep prop
+                            if (refChangeTracker != null) refChangeTracker.RemoveRestoredDeletes(visitationHelper);
+                        }
 
-                    // Process 1-M and M-M properties
-                    foreach (var colProp in navProp.AsCollectionProperty<ITrackingCollection>())
-                    {
-                        colProp.EntityCollection.RemoveRestoredDeletes(visitationHelper);
+                        // Process 1-M and M-M properties
+                        foreach (var colProp in navProp.AsCollectionProperty<ITrackingCollection>())
+                        {
+                            colProp.EntityCollection.RemoveRestoredDeletes(visitationHelper);
+                        }
                     }
                 }
 
                 // Remove item if marked as deleted
-                var removedDeletes = changeTracker.GetChanges(true).Cast<ITrackable>().ToList();
                 if (item.TrackingState == TrackingState.Deleted)
                 {
                     var isTracking = changeTracker.Tracking;
                     changeTracker.Tracking = false;
-                    if (removedDeletes.Contains(item))
-                        items.Remove(item);
+                    items.RemoveAt(i);
                     changeTracker.Tracking = isTracking;
                 }
             }


### PR DESCRIPTION
The problem is with the part of `TrackableExtensions.RemoveRestoredDeletes`, which attempts to remove deletes which were temporarily restored:

```csharp
var removedDeletes = changeTracker.GetChanges(true).Cast<ITrackable>().ToList();
if (item.TrackingState == TrackingState.Deleted)
{
    var isTracking = changeTracker.Tracking;
    changeTracker.Tracking = false;
    if (removedDeletes.Contains(item))
        items.Remove(item);
    changeTracker.Tracking = isTracking;
}
```

Calling `changeTracker.GetChanges` again here seems to be the source of the problem.  Instead the `items.RemoveAt(i)` should be called.