### PR TITLE
Fix #141: Calling GetChanges multiple times does not capture additional changes

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
@@ -231,7 +231,7 @@ namespace TrackableEntities.Client.Tests.Extensions
             Assert.Same(addedDetail, origOrder.OrderDetails.Single(d => d.ProductId == 51)); // Ref equality
             Assert.Same(modifiedDetail, origOrder.OrderDetails.Single(d => d.ProductId == 42)); // Ref equality
             Assert.DoesNotContain(deletedDetail, origOrder.OrderDetails); // Detail deleted
-            ICollection cachedDeletes = ((ITrackingCollection)origOrder.OrderDetails).GetChanges(true);
+            ICollection cachedDeletes = ((ITrackingCollection)origOrder.OrderDetails).CachedDeletes;
             Assert.Empty(cachedDeletes); // Cached deletes have been removed
         }
 
@@ -444,7 +444,7 @@ namespace TrackableEntities.Client.Tests.Extensions
             Assert.Same(addedNewTerritory, employee.Territories.Single(t => t.TerritoryId == "91360")); // Ref equality
             Assert.Same(modifiedTerritory, employee.Territories.Single(t => t.TerritoryId == "01730")); // Ref equality
             Assert.DoesNotContain(deletedTerritory, employee.Territories); // Detail deleted
-            ICollection cachedDeletes = ((ITrackingCollection)employee.Territories).GetChanges(true);
+            ICollection cachedDeletes = ((ITrackingCollection)employee.Territories).CachedDeletes;
             Assert.Empty(cachedDeletes); // Cached deletes have been removed
         }
 

--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -660,6 +660,37 @@ namespace TrackableEntities.Client.Tests
 
             // Assert
             Assert.Equal(0, employee.Territories.Count);
+            Assert.Equal(3, changes[0].Territories.Count);
+            Assert.Equal(TrackingState.Deleted, changes[0].Territories[0].TrackingState);
+            Assert.Equal(TrackingState.Deleted, changes[0].Territories[1].TrackingState);
+            Assert.Equal(TrackingState.Deleted, changes[0].Territories[2].TrackingState);
+        }
+
+        [Fact]
+        public void Calling_Get_Changes_Multiple_Times_Should_Be_Possible()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var employee = database.Employees[0];
+            var changeTracker = new ChangeTrackingCollection<Employee>(employee);
+
+            // Delete all territories, so employee.Territories.Count is 0
+            employee.Territories.Remove(employee.Territories[2]);
+            var changesA = changeTracker.GetChanges();
+            employee.Territories.Remove(employee.Territories[1]);
+            var changesB = changeTracker.GetChanges();
+            employee.Territories.Remove(employee.Territories[0]);
+            var changesC = changeTracker.GetChanges();
+
+            // Act
+            var changes = changeTracker.GetChanges();
+
+            // Assert
+            Assert.Equal(0, employee.Territories.Count);
+            Assert.Equal(3, changes[0].Territories.Count);
+            Assert.Equal(TrackingState.Deleted, changes[0].Territories[0].TrackingState);
+            Assert.Equal(TrackingState.Deleted, changes[0].Territories[1].TrackingState);
+            Assert.Equal(TrackingState.Deleted, changes[0].Territories[2].TrackingState);
         }
 
         #endregion

--- a/Source/TrackableEntities.Client/ChangeTrackingCollection.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingCollection.cs
@@ -20,7 +20,7 @@ namespace TrackableEntities.Client
         where TEntity : class, ITrackable, INotifyPropertyChanged
     {
         // Deleted entities cache
-        readonly private Collection<TEntity> _deletedEntities = new Collection<TEntity>();
+        private readonly Collection<TEntity> _deletedEntities = new Collection<TEntity>();
 
         /// <summary>
         /// Event for when an entity in the collection has changed its tracking state.
@@ -539,20 +539,31 @@ namespace TrackableEntities.Client
         /// <summary>
         /// Get entities that have been added, modified or deleted.
         /// </summary>
-        /// <param name="cachedDeletesOnly">True to return only cached deletes</param>
         /// <returns>Collection containing only changed entities</returns>
-        ITrackingCollection ITrackingCollection.GetChanges(bool cachedDeletesOnly)
+        ITrackingCollection ITrackingCollection.GetChanges()
         {
-            // Get removed deletes only
-            if (cachedDeletesOnly)
-                return new ChangeTrackingCollection<TEntity>(_deletedEntities, true);
-
             // Get changed items in this tracking collection
             var changes = (from existing in this
                            where existing.TrackingState != TrackingState.Unchanged
                            select existing)
                           .Union(_deletedEntities);
             return new ChangeTrackingCollection<TEntity>(changes, true);
+        }
+
+        /// <summary>
+        /// Turn change-tracking on and off without graph traversal (internal use).
+        /// </summary>
+        bool ITrackingCollection.InternalTracking
+        {
+            set { _tracking = value; }
+        }
+
+        /// <summary>
+        /// Get deleted entities which have been cached.
+        /// </summary>
+        ICollection ITrackingCollection.CachedDeletes
+        {
+            get { return _deletedEntities; }
         }
 
         /// <summary>

--- a/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
@@ -160,7 +160,7 @@ namespace TrackableEntities.Client
                 foreach (var colProp in navProp.AsCollectionProperty<ITrackingCollection>())
                 {
                     // See if there are any cached deletes
-                    var cachedDeletes = colProp.EntityCollection.GetChanges(true);
+                    var cachedDeletes = colProp.EntityCollection.CachedDeletes;
                     if (cachedDeletes.Count > 0) return true;
 
                     // See if child entities have changes

--- a/Source/TrackableEntities.Client/ITrackingCollection.cs
+++ b/Source/TrackableEntities.Client/ITrackingCollection.cs
@@ -20,6 +20,11 @@ namespace TrackableEntities.Client
         bool Tracking { get; set; }
 
         /// <summary>
+        /// Turn change-tracking on and off without graph traversal (internal use).
+        /// </summary>
+        bool InternalTracking { set; }
+
+        /// <summary>
         /// For internal use.
         /// </summary>
         void SetTracking(bool value, Common.ObjectVisitationHelper visitationHelper,
@@ -28,9 +33,13 @@ namespace TrackableEntities.Client
         /// <summary>
         /// Get entities that have been marked as Added, Modified or Deleted.
         /// </summary>
-        /// <param name="cachedDeletesOnly">True to return only cached deletes</param>
         /// <returns>Collection containing only changed entities</returns>
-        ITrackingCollection GetChanges(bool cachedDeletesOnly);
+        ITrackingCollection GetChanges();
+
+        /// <summary>
+        /// Get deleted entities which have been cached. 
+        /// </summary>
+        ICollection CachedDeletes { get; }
 
         /// <summary>
         /// Remove deleted entities which have been cached.

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -181,9 +181,9 @@ namespace TrackableEntities.Client
                 if (item.TrackingState == TrackingState.Deleted)
                 {
                     var isTracking = changeTracker.Tracking;
-                    changeTracker.Tracking = false;
+                    changeTracker.InternalTracking = false;
                     items.RemoveAt(i);
-                    changeTracker.Tracking = isTracking;
+                    changeTracker.InternalTracking = isTracking;
                 }
             }
         }
@@ -198,20 +198,20 @@ namespace TrackableEntities.Client
             ObjectVisitationHelper.EnsureCreated(ref visitationHelper);
 
             // Get cached deletes
-            var removedDeletes = changeTracker.GetChanges(true).Cast<ITrackable>().ToList();
+            var removedDeletes = changeTracker.CachedDeletes;
 
             // Restore deleted items
-            if (removedDeletes.Any())
+            if (removedDeletes.Count > 0)
             {
                 var isTracking = changeTracker.Tracking;
-                changeTracker.Tracking = false;
+                changeTracker.InternalTracking = false;
                 foreach (var delete in removedDeletes)
                 {
                     var items = changeTracker as IList;
                     if (items != null && !items.Contains(delete))
                         items.Add(delete);
                 }
-                changeTracker.Tracking = isTracking;
+                changeTracker.InternalTracking = isTracking;
             }
 
             foreach (var item in changeTracker.Cast<ITrackable>())


### PR DESCRIPTION
Fixed problem with `GetChanges` which resulted in additional changes not being recorded.  The cause was that tracking had been turned in M-M entities in the object graph through recursion.

To solve the problem, I created a write-only `InternalTracking` property for setting Tracking without graph traversal and recursion.

While I was at it, I also simplified the `GetChanges` method on `ITrackingCollection` to remove the  `cachedDeletesOnly` parameter, and added a `CachedDeletes` property, so that cached deletes could be retrieved without creating a new ChangeTrackingCollection.