### PR TITLE
added Test Apply_Changes_Should_Mark_Added_Territories_And_Same_Remov…

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindDbContextTests.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindDbContextTests.cs
@@ -1152,7 +1152,7 @@ namespace TrackableEntities.EF5.Tests
 			var territory3 = employee.Territories[2];
 			var territory4 = nw.Territories[3];
 			territory4.TrackingState = TrackingState.Added;
-			employee.Territories.Add(territory4);
+            employee.Territories.Add(territory4);
 
 			// Act
 			context.ApplyChanges(employee);
@@ -1251,37 +1251,85 @@ namespace TrackableEntities.EF5.Tests
 			Assert.True(context.RelatedItemHasBeenAdded(employee, territory3));
 		}
 
-		[Fact]
-		public void Apply_Changes_Should_Mark_Added_Employee_As_Added_And_Added_Territories_As_Unchanged()
-		{
-			// NOTE: Because parent is added, added children will be marked as unchanged
-			// but added to the M-M relation
+        [Fact]
+        public void Apply_Changes_Should_Mark_Added_Employee_As_Added_And_Added_Territories_As_Unchanged()
+        {
+            // NOTE: Because parent is added, added children will be marked as unchanged
+            // but added to the M-M relation
 
-			// Arrange
-			var context = TestsHelper.CreateNorthwindDbContext(CreateNorthwindDbOptions);
-			var nw = new MockNorthwind();
-			var employee = nw.Employees[0];
-			employee.TrackingState = TrackingState.Added;
-			var territory1 = employee.Territories[0];
-			var territory2 = employee.Territories[1];
-			var territory3 = employee.Territories[2];
-			var territory4 = nw.Territories[3];
-			territory4.TrackingState = TrackingState.Added;
-			employee.Territories.Add(territory4);
+            // Arrange
+            var context = TestsHelper.CreateNorthwindDbContext(CreateNorthwindDbOptions);
+            var nw = new MockNorthwind();
+            var employee = nw.Employees[0];
+            employee.TrackingState = TrackingState.Added;
+            var territory1 = employee.Territories[0];
+            var territory2 = employee.Territories[1];
+            var territory3 = employee.Territories[2];
+            var territory4 = nw.Territories[3];
+            territory4.TrackingState = TrackingState.Added;
+            employee.Territories.Add(territory4);
 
-			// Act
-			context.ApplyChanges(employee);
+            // Act
+            context.ApplyChanges(employee);
 
-			// Assert
-			Assert.Equal(EntityState.Added, context.Entry(employee).State);
-			Assert.Equal(EntityState.Unchanged, context.Entry(territory1).State);
-			Assert.Equal(EntityState.Unchanged, context.Entry(territory2).State);
-			Assert.Equal(EntityState.Unchanged, context.Entry(territory3).State);
-			Assert.Equal(EntityState.Unchanged, context.Entry(territory4).State);
-			Assert.True(context.RelatedItemHasBeenAdded(employee, territory4));
-		}
+            // Assert
+            Assert.Equal(EntityState.Added, context.Entry(employee).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(territory1).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(territory2).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(territory3).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(territory4).State);
+            Assert.True(context.RelatedItemHasBeenAdded(employee, territory4));
+        }
 
-		[Fact]
+
+        [Fact]
+	    public void Apply_Changes_Should_Mark_Added_Territories_And_Same_Removed_Territory_As_Unchanged()
+	    {
+            // Arrange
+            var context = TestsHelper.CreateNorthwindDbContext(CreateNorthwindDbOptions);
+            var nw = new MockNorthwind();
+
+            var employee1 = nw.Employees[0];
+
+	        var employee2 = nw.Employees[1];
+
+            // We have a company with 2 Employees
+            var company = new List<ITrackable>
+            {
+                employee1,
+                employee2
+             };
+
+            var territory1 = employee1.Territories[0];
+
+            var sameTerritoryButOtherObj = new Territory
+            {
+                TrackingState = TrackingState.Added,
+                TerritoryId = territory1.TerritoryId,
+                TerritoryDescription = territory1.TerritoryDescription,
+                Area = territory1.Area,
+                AreaId = territory1.AreaId
+            };
+
+            // We remove Territitory 1 from employee1
+            territory1.TrackingState = TrackingState.Deleted;
+
+            // Add same Territory to employee2 but not Object is not ReferenceEquals
+            employee2.Territories.Add(sameTerritoryButOtherObj);
+
+            // Act
+            context.ApplyChanges(company);
+
+            // Assert
+            Assert.Equal(EntityState.Unchanged, context.Entry(employee1).State);
+            Assert.Equal(EntityState.Unchanged, context.Entry(employee2).State);
+            Assert.Equal(EntityState.Deleted, context.Entry(territory1).State);
+            Assert.True(context.RelatedItemHasBeenAdded(employee2, sameTerritoryButOtherObj));
+        }
+
+
+
+	    [Fact]
 		public void Apply_Changes_Should_Mark_Added_Employee_As_Added_And_Deleted_Territories_As_Deleted()
 		{
 			// NOTE: If a deleted child is assocated with an added parent, 


### PR DESCRIPTION
Added this test-case to describe the issue i'am facing with N-M Entities.

This is a simple example of my Use-Case.

I try to describe it in the northwind-shema.
Let's say i have a List of Employees.
And I have a List of Territories.

So I want to remove one Territory from one employee and add the same Territory to another employee.

But the Territory-Object is in both cases not the same, it can't be the same because one is in trackingState.Added and the other one in deleted.

Having this in object-graph leads to the 

> System.InvalidOperationException: Attaching an entity of type 'TrackableEntities.EF.Tests.NorthwindModels.Territory' failed because another entity of the same type already has the same primary key value. This can happen when using the 'Attach' method or setting the state of an entity to 'Unchanged' or 'Modified' if any entities in the graph have conflicting key values. This may be because some entities are new and have not yet received database-generated key values. In this case use the 'Add' method or the 'Added' entity state to track the graph and then set the state of non-new entities to 'Unchanged' or 'Modified' as appropriate.

because the Entity is already Attached to the Context

Exception comes from  SetEntityState

` // Set state normally if we cannot perform interception
            if (interceptors == null)
            {
                context.Entry(item).State = state; <-- This fails if a other Territory with same id is already attached
                return;
            }`

My usecase is a little bit more complex but in short this is what i facing.
My Question is how to solve this or is this  (maybe unwanted behavior ) in ApplyChanges and if we should maybe check if the entity is already attached and in State unchanged and if so to decide to not set the State again.
