### PR TITLE
Entity properties marked NotMapped should not be marked as modified

### DIFF
--- a/Source/TrackableEntities.EF.5/DbContextExtensions.cs
+++ b/Source/TrackableEntities.EF.5/DbContextExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Collections;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Reflection;

--- a/Source/TrackableEntities.EF.5/DbContextExtensions.cs
+++ b/Source/TrackableEntities.EF.5/DbContextExtensions.cs
@@ -209,8 +209,9 @@ namespace TrackableEntities.EF5
                     SetEntityState(context, item, parent, propertyName, EntityState.Unchanged, interceptors);
                     foreach (var property in item.ModifiedProperties)
                     {                        
-                        if(item.GetType().GetRuntimeProperty(property)?.GetCustomAttribute<NotMappedAttribute>() != null)
-                        context.Entry(item).Property(property).IsModified = true;
+                        var propertyInfo = item.GetType().GetRuntimeProperty(property);
+                        if(propertyInfo != null && propertyInfo.GetCustomAttribute<NotMappedAttribute>() == null)
+                            context.Entry(item).Property(property).IsModified = true;
                     }
                 }
                 else

--- a/Source/TrackableEntities.EF.5/DbContextExtensions.cs
+++ b/Source/TrackableEntities.EF.5/DbContextExtensions.cs
@@ -208,7 +208,10 @@ namespace TrackableEntities.EF5
                     // Mark modified properties
                     SetEntityState(context, item, parent, propertyName, EntityState.Unchanged, interceptors);
                     foreach (var property in item.ModifiedProperties)
+                    {                        
+                        if(item.GetType().GetRuntimeProperty(property)?.GetCustomAttribute<NotMappedAttribute>() != null)
                         context.Entry(item).Property(property).IsModified = true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Hi,

1. Entity properties marked as `NotMapped`, shouldn't be `entry.Property(prop).IsModified` marked upon.
2. Verify all properties in `ModifiedProperties` actually exist in the entity, they might be removed during serialization, or added manually.