### PR TITLE
Change connection strings to use local db

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/App.config
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/App.config
@@ -8,10 +8,10 @@
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>
         <!--Use this for SQL Server Express or Full-->
-        <parameter value="Data Source=(local)\sqlexpress; Integrated Security=True; MultipleActiveResultSets=True" />
+        <!--parameter value="Data Source=(local)\MSSQLSERVER; Integrated Security=True; MultipleActiveResultSets=True" /-->
 
         <!--Use this for SQL LocalDB-->
-        <!--<parameter value="Data Source=(localdb)\MSSQLLocalDB; Integrated Security=True; MultipleActiveResultSets=True" />-->
+        <parameter value="Data Source=(localdb)\MSSQLLocalDB; Integrated Security=True; MultipleActiveResultSets=True" />
       </parameters>
     </defaultConnectionFactory>
   </entityFramework>

--- a/Source/Tests/TrackableEntities.EF.6.Tests/App.config
+++ b/Source/Tests/TrackableEntities.EF.6.Tests/App.config
@@ -5,14 +5,14 @@
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
     <!--Use this for SQL Server Express or Full-->
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <!--defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" /-->
 
     <!--Use this for SQL LocalDB-->
-    <!--<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
         <parameter value="mssqllocaldb" />
       </parameters>
-    </defaultConnectionFactory>-->
+    </defaultConnectionFactory>
     
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />


### PR DESCRIPTION
Since VS' default SQL Server is LocalDB, and to spare the hassle of installing SQL Express.