### PR TITLE
Failing test for providing deleting reference properties

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -577,7 +577,7 @@ namespace TrackableEntities.Client.Tests
             var database = new MockNorthwind();
             var changeTracker = new ChangeTrackingCollection<Product>(true);
             var product = database.Products[0];
-            changeTracker.Add(product);
+            changeTracker.Add(product);    
 
             // Act
             var changes = changeTracker.GetChanges();
@@ -616,6 +616,25 @@ namespace TrackableEntities.Client.Tests
 
             // Assert
             Assert.Equal(TrackingState.Deleted, changes.First().TrackingState);
+        }
+
+        [Fact]
+        public void GetChanges_Should_Return_Deleted_References()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var product = database.Products[0];
+            var category = product.Category;
+            var changeTracker = new ChangeTrackingCollection<Product>(product);
+
+            // Act
+            product.Category = new Category();
+
+            // Assert
+            Assert.Equal(TrackingState.Added, product.Category.TrackingState);
+            // We should add another property in the ITrackable interface that returns the deleted interface.
+            // Maybe as a dictionary specifying property name
+            Assert.True(false); //product.DeletedReferences[nameof(Product.Category)].Contains(category);
         }
 
         [Fact]


### PR DESCRIPTION
We should allow reference properties' container entities to carry their old values, and when needed, be serialized back to server.
I'd like to see the `*ChangeTracker` properties vanish in favor of using an `IDictionary<string, ITrackable> DeletedReferences`, which will be part of the common `ITrackable`, and will return the deleted children of the current entity.

The default should be to exclude the deleted ref. properties, but we should give option to setup dependent/independent props.
For example `Product.Category` is independent, because `Category` is standalone regardless of the `Product`s using it, while `Customer.Address` is dependent, meaning when I set `Customer.Address` to a new address, I'd want the old `Address` entity to be deleted. And its deletion might have to be smart because it might carry a foreign key of the `Customer` which can be the same as the `Added` entity, so we first need to delete old, save than add `ApplyChanges` and save again.