### PR TITLE
Added NPC into the main BaseEntity

### DIFF
--- a/Source/TrackableEntities.Client.Net45/EntityBaseNet45.cs
+++ b/Source/TrackableEntities.Client.Net45/EntityBaseNet45.cs
@@ -32,17 +32,5 @@ namespace TrackableEntities.Client
         [NotMapped]
         [DataMember]
         public Guid EntityIdentifier { get; set; }
-
-        /// <summary>
-        /// Fire PropertyChanged event.
-        /// </summary>
-        /// <param name="propertyName">Property name.</param>
-        protected void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
-        }
     }
 }

--- a/Source/TrackableEntities.Client/EntityBase.cs
+++ b/Source/TrackableEntities.Client/EntityBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 
 namespace TrackableEntities.Client
 {
@@ -23,17 +24,18 @@ namespace TrackableEntities.Client
             (Expression<Func<TResult>> property)
         {
             string propertyName = ((MemberExpression)property.Body).Member.Name;
+            // ReSharper disable once ExplicitCallerInfoArgument
             NotifyPropertyChanged(propertyName);
         }
 
-        /// <summary>
-        /// Fire PropertyChanged event.
-        /// </summary>
-        /// <param name="propertyName">Property name.</param>
+    /// <summary>
+    /// Fire PropertyChanged event.
+    /// </summary>
+    /// <param name="propertyName">Property name.</param>
 #if NET40
-        protected virtual void NotifyPropertyChanged(string propertyName)
+    protected virtual void NotifyPropertyChanged(string propertyName)
 #else
-        protected virtual void NotifyPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = "")
+        protected virtual void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
 #endif
         {
             if (PropertyChanged != null)
@@ -47,7 +49,7 @@ namespace TrackableEntities.Client
         /// </summary>
         public void SetEntityIdentifier()
         {
-            if (EntityIdentifier == default(Guid))
+            if (EntityIdentifier == Guid.Empty)
                 EntityIdentifier = Guid.NewGuid();
         }
 

--- a/Source/TrackableEntities.Client/EntityBase.cs
+++ b/Source/TrackableEntities.Client/EntityBase.cs
@@ -23,11 +23,24 @@ namespace TrackableEntities.Client
             (Expression<Func<TResult>> property)
         {
             string propertyName = ((MemberExpression)property.Body).Member.Name;
+            NotifyPropertyChanged(propertyName);
+        }
+
+        /// <summary>
+        /// Fire PropertyChanged event.
+        /// </summary>
+        /// <param name="propertyName">Property name.</param>
+#if NET40
+        protected virtual void NotifyPropertyChanged(string propertyName)
+#else
+        protected virtual void NotifyPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = "")
+#endif
+        {
             if (PropertyChanged != null)
             {
                 PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
             }
-        }
+        }              
 
         /// <summary>
         /// Generate entity identifier used for correlation with MergeChanges (if not yet done)


### PR DESCRIPTION
Added NPC into the main BaseEntity, so portable classes also get the `CallerMemberName` attribute if they're above .NET 4.5.

Fixes #161.