### PR TITLE
Revert "Added a fix to ignore merging changes of unidentifiable entities."

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
@@ -15,29 +15,7 @@ namespace TrackableEntities.Client.Tests.Extensions
         #region MergeChanges Tests
 
         #region MergeChanges: Single Entity
-    
-        [Fact]
-        public void MergeChanges_Skip_EmptyIDs()
-        {
-            // Arrange
-            var database = new MockNorthwind();
-            var origOrder = database.Orders[0];
-            var changeTracker = new ChangeTrackingCollection<Order>(origOrder);
-            origOrder.CustomerId = "ALFKI";
-            var updatedOrder = UpdateOrders(database, origOrder)[0];
-
-            updatedOrder.Customer.EntityIdentifier = Guid.Empty;
-            updatedOrder.Customer.CustomerId = string.Empty;
-
-            // Act
-            changeTracker.MergeChanges(updatedOrder);
-
-            // Assert
-            Assert.Equal(updatedOrder.CustomerId, origOrder.CustomerId);
-            Assert.NotEqual(updatedOrder.Customer.CustomerId, origOrder.Customer.CustomerId);
-            Assert.Equal(updatedOrder.OrderDate, origOrder.OrderDate);
-        }
-
+        
         [Fact]
         public void MergeChanges_Should_Set_Properties_For_Modified_Order_With_Updated_Customer()
         {

--- a/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingExtensions.cs
@@ -67,8 +67,6 @@ namespace TrackableEntities.Client
                 var origItem = originalChangeTracker.Cast<ITrackable>()
                     .GetEquatableItem(updatedItem, isTrackableRef);
                 if (origItem == null) continue;
-                if (!(origItem is IEquatable<IIdentifiable> identifiable && identifiable.Equals(updatedItem as IIdentifiable)))
-                    continue;
 
                 // Back fill entity identity on trackable ref
                 if (isTrackableRef)


### PR DESCRIPTION
There are 4 failing test that need to be fixed.
- Run all the tests to see which ones are failing.