### PR TITLE
Fix LoadRelatedEntities with Non-Matching Foreign Keys

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/Contexts/FamilyDbContext.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/Contexts/FamilyDbContext.cs
@@ -34,6 +34,8 @@ namespace TrackableEntities.EF.Tests.Contexts
 
         public DbSet<Parent> Parents { get; set; }
         public DbSet<Child> Children { get; set; }
+        public DbSet<Contact> Contacts { get; set; }
+        public DbSet<ContactDetail> ContactDetails { get; set; }
 
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {

--- a/Source/Tests/TrackableEntities.EF.5.Tests/FamilyModels/Contact.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/FamilyModels/Contact.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TrackableEntities.EF.Tests.FamilyModels
+{
+    public class Contact : ITrackable
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [ForeignKey(nameof(ContactDetail))]
+        public int ContactDetailId { get; set; }
+
+        public ContactDetail ContactDetail { get; set; }
+
+        [NotMapped]
+        public TrackingState TrackingState { get; set; }
+
+        [NotMapped]
+        public ICollection<string> ModifiedProperties { get; set; }
+    }
+}

--- a/Source/Tests/TrackableEntities.EF.5.Tests/FamilyModels/ContactDetail.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/FamilyModels/ContactDetail.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TrackableEntities.EF.Tests.FamilyModels
+{
+    public class ContactDetail : ITrackable
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public string Data { get; set; }
+        [NotMapped]
+        public TrackingState TrackingState { get; set; }
+
+        [NotMapped]
+        public ICollection<string> ModifiedProperties { get; set; }
+    }
+}

--- a/Source/Tests/TrackableEntities.EF.5.Tests/TrackableEntities.EF.5.Tests.csproj
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/TrackableEntities.EF.5.Tests.csproj
@@ -70,6 +70,8 @@
       <Link>Constants.cs</Link>
     </Compile>
     <Compile Include="FamilyModels\Address.cs" />
+    <Compile Include="FamilyModels\Contact.cs" />
+    <Compile Include="FamilyModels\ContactDetail.cs" />
     <Compile Include="StateInterceptorTests.cs" />
     <Compile Include="StateChangeInterceptorTests.cs" />
     <Compile Include="Contexts\NorthwindDbContext.cs" />

--- a/Source/Tests/TrackableEntities.EF.6.Tests/TrackableEntities.EF.6.Tests.csproj
+++ b/Source/Tests/TrackableEntities.EF.6.Tests/TrackableEntities.EF.6.Tests.csproj
@@ -93,6 +93,12 @@
     <Compile Include="..\TrackableEntities.EF.5.Tests\FamilyModels\Child.cs">
       <Link>FamilyModels\Child.cs</Link>
     </Compile>
+    <Compile Include="..\TrackableEntities.EF.5.Tests\FamilyModels\Contact.cs">
+      <Link>FamilyModels\Contact.cs</Link>
+    </Compile>
+    <Compile Include="..\TrackableEntities.EF.5.Tests\FamilyModels\ContactDetail.cs">
+      <Link>FamilyModels\ContactDetail.cs</Link>
+    </Compile>
     <Compile Include="..\TrackableEntities.EF.5.Tests\FamilyModels\Parent.cs">
       <Link>FamilyModels\Parent.cs</Link>
     </Compile>


### PR DESCRIPTION
LoadRelatedEntities throws an exception when foreign key name does not match related primary key name.

Fixes #197.
Replaces #205.