### PR TITLE
Add onLoading, onError callbacks to LoadRelatedEntities.

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/FamilyModels/Contact.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/FamilyModels/Contact.cs
@@ -9,10 +9,10 @@ namespace TrackableEntities.EF.Tests.FamilyModels
         [Key]
         public int Id { get; set; }
 
-        [ForeignKey(nameof(ContactDetail))]
-        public int ContactDetailId { get; set; }
+        [ForeignKey(nameof(ContactCategory))]
+        public int ContactCategoryId { get; set; }
 
-        public ContactCategory ContactDetail { get; set; }
+        public ContactCategory ContactCategory { get; set; }
 
         public ContactData ContactData { get; set; }
 


### PR DESCRIPTION
- Revert commit d2bb2336 so that 1-1 with non-matching keys throws.
- Resolves issue #165.