### PR TITLE
IsComplexType throws NullReferenceException

### DIFF
--- a/Source/TrackableEntities.EF.5/DbContextExtensions.cs
+++ b/Source/TrackableEntities.EF.5/DbContextExtensions.cs
@@ -551,7 +551,7 @@ namespace TrackableEntities.EF5
             StructuralType oType = workspace.GetItems<StructuralType>(DataSpace.OSpace)
                 .Where(e => e.FullName == entityType.FullName).SingleOrDefault();
 
-            return oType.BuiltInTypeKind == BuiltInTypeKind.ComplexType;
+            return oType != null && oType.BuiltInTypeKind == BuiltInTypeKind.ComplexType;
         }   
 
         private static bool IsMappedProperty(this DbContext dbContext, Type entityType, string propertyName)


### PR DESCRIPTION
This happens when we have a readonly property that exposes a certain type.
It makes TE think that the type is in the model while it's not.